### PR TITLE
Add image consumer

### DIFF
--- a/d2l-richtext.html
+++ b/d2l-richtext.html
@@ -26,10 +26,22 @@
 				imageConsumer: {
 					type: String,
 					default: null
-				}
+				},
+				getToken: Function
+			},
+			listeners: {
+				'get-token': '_onGetTokenRequest'
 			},
 			ready: function() {
 				this._onRichTextChanged(this.richtext);
+			},
+			_onGetTokenRequest: function(e) {
+				e.stopPropagation();
+				if (this.getToken && e.detail.callback) {
+					this.getToken().then(function(token) {
+						e.detail.callback(token);
+					});
+				}
 			},
 			_onRichTextChanged: function(richtext) {
 				if (!richtext) {
@@ -38,13 +50,15 @@
 				this._processedRichtext = this._replaceConsumers({
 					'd2l-richtext-quicklink': this.quicklinkConsumer,
 					'd2l-richtext-image': this.imageConsumer
-				});
+				}, richtext);
 			},
 			_replaceConsumers: function(consumerMap, richtext) {
 				var curVal = richtext;
 				Object.keys(consumerMap).forEach(function(key) {
-					var regex = new RegExp('(</? ?)' + key, 'g');
-					curVal = this._replaceIfProviderGiven(regex, consumerMap[key], richtext);
+					if (consumerMap[key]) {
+						var regex = new RegExp('(</? ?)' + key, 'g');
+						curVal = this._replaceIfProviderGiven(regex, consumerMap[key], richtext);
+					}
 				}.bind(this));
 				return curVal;
 			},

--- a/d2l-richtext.html
+++ b/d2l-richtext.html
@@ -26,22 +26,10 @@
 				imageConsumer: {
 					type: String,
 					default: null
-				},
-				getToken: Function
-			},
-			listeners: {
-				'get-token': '_onGetTokenRequest'
-			},
+				}
+			}
 			ready: function() {
 				this._onRichTextChanged(this.richtext);
-			},
-			_onGetTokenRequest: function(e) {
-				e.stopPropagation();
-				if (this.getToken && e.detail.callback) {
-					this.getToken().then(function(token) {
-						e.detail.callback(token);
-					});
-				}
 			},
 			_onRichTextChanged: function(richtext) {
 				if (!richtext) {

--- a/d2l-richtext.html
+++ b/d2l-richtext.html
@@ -22,6 +22,10 @@
 				quicklinkConsumer: {
 					type: String,
 					default: null
+				},
+				imageConsumer: {
+					type: String,
+					default: null
 				}
 			},
 			ready: function() {
@@ -31,9 +35,18 @@
 				if (!richtext) {
 					return;
 				}
+				this._processedRichtext = this._replaceConsumers({
+					'd2l-richtext-quicklink': this.quicklinkConsumer,
+					'd2l-richtext-image': this.imageConsumer
+				});
+			},
+			_replaceConsumers: function(consumerMap, richtext) {
 				var curVal = richtext;
-				curVal = this._replaceIfProviderGiven(/(<\/? ?)d2l-richtext-quicklink/g, this.quicklinkConsumer, richtext);
-				this._processedRichtext = curVal;
+				Object.keys(consumerMap).forEach(function(key) {
+					var regex = new RegExp('(</? ?)' + key, 'g');
+					curVal = this._replaceIfProviderGiven(regex, consumerMap[key], richtext);
+				}.bind(this));
+				return curVal;
 			},
 			_replaceIfProviderGiven: function(tagName, provider, richtext) {
 				if (!provider) {

--- a/d2l-richtext.html
+++ b/d2l-richtext.html
@@ -27,7 +27,7 @@
 					type: String,
 					default: null
 				}
-			}
+			},
 			ready: function() {
 				this._onRichTextChanged(this.richtext);
 			},


### PR DESCRIPTION
This adds an image consumer option and allows the user to pass in a getToken function which can then be called by consumers

Related: https://github.com/Brightspace/d2l-richtext-parent/pull/4 (no consumer at the moment, but it does pass getToken through)